### PR TITLE
BUILDBOT: Add toolchain for RISC OS

### DIFF
--- a/toolchains/common/functions.sh
+++ b/toolchains/common/functions.sh
@@ -52,6 +52,15 @@ __do_http_fetch () {
 	do_patch
 }
 
+__do_svn_fetch () {
+	if [ -d "$1"*/ ]; then
+		rm -rf "$1"*/
+	fi
+	svn co "$2" "$1"
+	cd "$1"*/
+	do_patch
+}
+
 __do_configure () {
 	./configure --prefix=$PREFIX --host=$HOST --disable-shared "$@"
 }
@@ -81,7 +90,7 @@ __error () {
 # Create wrapper functions so that functions-platform.sh can override functions
 # but still use base function (Poor man's inheritance)
 # Aliases are expanded at definition time so that's not the good way
-for f in do_make_bdir do_clean_bdir do_patch do_pkg_fetch do_http_fetch \
+for f in do_make_bdir do_clean_bdir do_patch do_pkg_fetch do_http_fetch do_svn_fetch \
 	do_configure do_cmake do_make log error; do
 	eval "$f () { __$f \"\$@\"; }"
 done

--- a/toolchains/common/packages/freetype/patches/0001-Fix-compilation-with-GCC-4.7.patch
+++ b/toolchains/common/packages/freetype/patches/0001-Fix-compilation-with-GCC-4.7.patch
@@ -1,0 +1,30 @@
+From b87a179a24114108597b231bfd7304da86254c97 Mon Sep 17 00:00:00 2001
+From: Cameron Cawley <ccawley2011@gmail.com>
+Date: Tue, 17 Sep 2019 20:47:39 +0100
+Subject: [PATCH] Fix compilation with GCC 4.7
+
+---
+ src/sfnt/pngshim.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/src/sfnt/pngshim.c b/src/sfnt/pngshim.c
+index ca85d9751..e1e3d7141 100644
+--- a/src/sfnt/pngshim.c
++++ b/src/sfnt/pngshim.c
+@@ -60,10 +60,11 @@
+     /* The `vector_size' attribute was introduced in gcc 3.1, which */
+     /* predates clang; the `__BYTE_ORDER__' preprocessor symbol was */
+     /* introduced in gcc 4.6 and clang 3.2, respectively.           */
+-    /* `__builtin_shuffle' for gcc was introduced in gcc 4.7.0.     */
++    /* `__builtin_shuffle' for gcc was introduced in gcc 4.7.0,     */
++    /* however, this causes an internal compiler error on gcc 4.7.  */
+ #if ( ( defined( __GNUC__ )                                &&             \
+         ( ( __GNUC__ >= 5 )                              ||               \
+-        ( ( __GNUC__ == 4 ) && ( __GNUC_MINOR__ >= 7 ) ) ) )         ||   \
++        ( ( __GNUC__ == 4 ) && ( __GNUC_MINOR__ >= 8 ) ) ) )         ||   \
+       ( defined( __clang__ )                                       &&     \
+         ( ( __clang_major__ >= 4 )                               ||       \
+         ( ( __clang_major__ == 3 ) && ( __clang_minor__ >= 2 ) ) ) ) ) && \
+-- 
+2.11.0
+

--- a/toolchains/common/packages/sdl-net1.2/build.sh
+++ b/toolchains/common/packages/sdl-net1.2/build.sh
@@ -1,0 +1,20 @@
+#! /bin/sh
+
+PACKAGE_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+HELPERS_DIR=$PACKAGE_DIR/../..
+. $HELPERS_DIR/functions.sh
+
+do_make_bdir
+
+do_pkg_fetch sdl-net1.2
+do_configure --with-sdl-prefix=$PREFIX
+
+# showinterfaces.c indirectly includes SDL_main.h which #defines main to
+# SDL_main when __ANDROID__ is defined, so it won't compile in the usual manner,
+# so just stub it out
+echo 'int main(){return 0;}' > showinterfaces.c
+
+do_make
+do_make install
+
+do_clean_bdir

--- a/toolchains/riscos/Dockerfile.m4
+++ b/toolchains/riscos/Dockerfile.m4
@@ -1,0 +1,95 @@
+FROM toolchains/common AS helpers
+
+m4_include(`paths.m4')m4_dnl
+
+m4_include(`packages.m4')m4_dnl
+
+FROM debian:stable-slim
+USER root
+
+WORKDIR /usr/src
+
+ENV GCCSDK_INSTALL_CROSSBIN=/usr/local/gccsdk/cross/bin HOST=arm-unknown-riscos
+ENV GCCSDK_INSTALL_ENV=/usr/local/gccsdk/env
+ENV PREFIX=$GCCSDK_INSTALL_ENV
+
+RUN apt-get update && \
+	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+		autogen \
+		m4 \
+		texinfo \
+		gcc \
+		g++ \
+		bison \
+		flex \
+		subversion \
+		bash \
+		gperf \
+		sed \
+		make \
+		libtool \
+		patch \
+		wget \
+		help2man \
+		pandoc && \
+	rm -rf /var/lib/apt/lists/*
+
+# Copy and execute each step separately to avoid invalidating cache
+COPY --from=helpers /lib-helpers/prepare.sh lib-helpers/
+RUN lib-helpers/prepare.sh
+
+COPY --from=helpers /lib-helpers/functions.sh lib-helpers/
+
+local_package(toolchain)
+
+local_package(iconv)
+
+local_package(bindhelp)
+
+local_package(tokenize)
+
+# TODO: http://www.riscos.info/websvn/listing.php?repname=gccsdk&path=%2Ftrunk%2Fautobuilder%2Fsupport%2Fnative-zip%2F
+
+ENV \
+	def_binaries(`${GCCSDK_INSTALL_CROSSBIN}/${HOST}-', `ar, as, c++filt, ld, nm, objcopy, objdump, ranlib, readelf, strings, strip') \
+	def_binaries(`${GCCSDK_INSTALL_CROSSBIN}/${HOST}-', `gcc, cpp, c++') \
+	CC=$GCCSDK_INSTALL_CROSSBIN/$HOST-gcc \
+	def_aclocal(`${PREFIX}') \
+	def_pkg_config(`${PREFIX}') \
+	PATH=$GCCSDK_INSTALL_CROSSBIN:$PATH
+
+helpers_package(zlib)
+
+helpers_package(libpng1.6, , CPPFLAGS="$CPPFLAGS -I$PREFIX/include" LDFLAGS="$LDFLAGS -L$PREFIX/lib")
+
+helpers_package(libjpeg-turbo)
+
+helpers_package(libmad)
+
+helpers_package(libogg)
+
+helpers_package(libvorbis)
+
+helpers_package(libvorbisidec)
+
+helpers_package(libtheora)
+
+helpers_package(flac, --with-pic=no)
+
+helpers_package(faad2)
+
+helpers_package(mpeg2dec, , CFLAGS="$CFLAGS -D__CRT__NO_INLINE")
+
+helpers_package(a52dec, , CFLAGS="$CFLAGS -D__CRT__NO_INLINE")
+
+# helpers_package(openssl)
+
+# helpers_package(curl)
+
+helpers_package(fluidsynth-lite, -DCMAKE_TOOLCHAIN_FILE=$GCCSDK_INSTALL_ENV/toolchain-riscos.cmake)
+
+helpers_package(freetype)
+
+local_package(libsdl1.2)
+
+helpers_package(sdl-net1.2)

--- a/toolchains/riscos/packages/bindhelp/build.sh
+++ b/toolchains/riscos/packages/bindhelp/build.sh
@@ -1,0 +1,13 @@
+#! /bin/sh
+
+PACKAGE_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+HELPERS_DIR=$PACKAGE_DIR/../..
+. $HELPERS_DIR/functions.sh
+
+do_make_bdir
+
+do_svn_fetch !OSLib https://svn.code.sf.net/p/ro-oslib/code/trunk/!OSLib
+
+do_make -C Tools/BindHelp install bindir="/usr/local/bin"
+
+do_clean_bdir

--- a/toolchains/riscos/packages/bindhelp/patches/bindhelp-fix.patch
+++ b/toolchains/riscos/packages/bindhelp/patches/bindhelp-fix.patch
@@ -1,0 +1,25 @@
+Index: Tools/oslib/os.h
+===================================================================
+--- a/Tools/oslib/os.h	(revision 455)
++++ b/Tools/oslib/os.h	(working copy)
+@@ -29,6 +29,7 @@
+ #endif
+ 
+ #if defined EXECUTE_ON_UNIX
++  #include <stdio.h>
+   #define OS_ERROR(e) (os_set_lasterr((e)))
+ #endif
+ 
+@@ -168,8 +169,12 @@
+ typedef byte os_f;
+       /*Deprecated 8-bit File handle. From OSLib V6.3 onwards the headers equate this name to its 32 bit equivalent, but the library retains this symbol for binary compatibility. To revert to legacy bahaviour, #define OSLIB_F8 during compilation.*/
+ 
++#ifdef EXECUTE_ON_UNIX
++typedef FILE* os_fw;
++#else
+ typedef bits os_fw;
+       /*Wide (32-bit) File handle*/
++#endif
+ 
+ typedef byte os_gcol;
+       /*Graphical colour, 6 or 8 bits*/

--- a/toolchains/riscos/packages/iconv/build.sh
+++ b/toolchains/riscos/packages/iconv/build.sh
@@ -1,0 +1,15 @@
+#! /bin/sh
+
+PACKAGE_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+HELPERS_DIR=$PACKAGE_DIR/../..
+. $HELPERS_DIR/functions.sh
+
+do_make_bdir
+
+do_http_fetch libiconv 'https://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.16.tar.gz' 'tar xzf'
+
+./configure --prefix=/usr/local --disable-shared --enable-extra-encodings "$@"
+do_make
+do_make install
+
+do_clean_bdir

--- a/toolchains/riscos/packages/libsdl1.2/build.sh
+++ b/toolchains/riscos/packages/libsdl1.2/build.sh
@@ -1,0 +1,15 @@
+#! /bin/sh
+
+PACKAGE_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+HELPERS_DIR=$PACKAGE_DIR/../..
+. $HELPERS_DIR/functions.sh
+
+do_make_bdir
+
+do_http_fetch SDL-0f0aa5935c12 'https://hg.libsdl.org/SDL/archive/0f0aa5935c12.tar.bz2' 'tar xjf'
+
+do_configure
+do_make
+do_make install
+
+do_clean_bdir

--- a/toolchains/riscos/packages/libsdl1.2/patches/video.patch
+++ b/toolchains/riscos/packages/libsdl1.2/patches/video.patch
@@ -1,0 +1,141 @@
+--- a/src/video/riscos/SDL_riscosASM.S.orig	2010-06-04 22:28:42.798530036 +0100
++++ b/src/video/riscos/SDL_riscosASM.S	2010-06-04 22:41:20.591027278 +0100
+@@ -1,75 +1,79 @@
+-;
+-;    SDL - Simple DirectMedia Layer
+-;    Copyright (C) 1997-2012 Sam Lantinga
+-;
+-;    This library is free software; you can redistribute it and/or
+-;    modify it under the terms of the GNU Library General Public
+-;    License as published by the Free Software Foundation; either
+-;    version 2 of the License, or (at your option) any later version.
+-;
+-;    This library is distributed in the hope that it will be useful,
+-;    but WITHOUT ANY WARRANTY; without even the implied warranty of
+-;    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+-;    Library General Public License for more details.
+-;
+-;    You should have received a copy of the GNU Library General Public
+-;    License along with this library; if not, write to the Free
+-;    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+-;
+-;    Sam Lantinga
+-;    slouken@libsdl.org
+-;
+-; Assembler routines for RISC OS display
+-;
+-
+-	AREA |C$$CODE|
+-
+-	EXPORT |RISCOS_Put32|
+-
+-; Display 32bpp to 32bpp, 1:1
+-;
+-; Code provided by Adrain Lees
+-;
+-; entry a1 -> destination
+-;       a2 =  dest width in pixels
+-;       a3 =  dest line length in bytes
+-;       a4 =  dest height in scanlines
+-;       arg5 -> source
+-;       arg6 =  byte offset from end of source line to start of next
++@
++@    SDL - Simple DirectMedia Layer
++@    Copyright (C) 1997-2004 Sam Lantinga
++@
++@    This library is free software; you can redistribute it and/or
++@    modify it under the terms of the GNU Library General Public
++@    License as published by the Free Software Foundation; either
++@    version 2 of the License, or (at your option) any later version.
++@
++@    This library is distributed in the hope that it will be useful,
++@    but WITHOUT ANY WARRANTY; without even the implied warranty of
++@    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++@    Library General Public License for more details.
++@
++@    You should have received a copy of the GNU Library General Public
++@    License along with this library; if not, write to the Free
++@    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
++@
++@    Sam Lantinga
++@    slouken@libsdl.org
++@
++@ Assembler routines for RISC OS display
++@
++
++@	AREA |C$$CODE|
++
++@	EXPORT |RISCOS_Put32|
++	.global RISCOS_Put32
++
++@ Display 32bpp to 32bpp, 1:1
++@
++@ Code provided by Adrain Lees
++@
++@ entry a1 -> destination
++@       a2 =  dest width in pixels
++@       a3 =  dest line length in bytes
++@       a4 =  dest height in scanlines
++@       arg5 -> source
++@       arg6 =  byte offset from end of source line to start of next
++
++@Arg5    *       10*4
++.set Arg5, 10*4
++.set Arg6, Arg5+4
+ 
+-Arg5    *       10*4
+-Arg6    *       Arg5+4
++@Arg6    *       Arg5+4
+ 
+-RISCOS_Put32    ROUT
++RISCOS_Put32:
+                 STMFD   sp!,{a2,v1-v6,sl,fp,lr}
+                 LDR     ip,[sp,#Arg5]
+                 MOV     lr,a1
+                 B       ucp64lp
+ 
+-00              ;tail strip of 1-15 pixels
++L00:            @tail strip of 1-15 pixels
+ 
+                 LDR     v1,[ip],#4
+-01              SUBS    a2,a2,#1
++L01:            SUBS    a2,a2,#1
+                 STR     v1,[lr],#4
+                 LDRHI   v1,[ip],#4
+-                BHI     %01
+-                B       %02
++                BHI     L01
++                B       L02
+ 
+-ucp64end        ADDS    a2,a2,#16
+-                BNE     %00
++ucp64end:       ADDS    a2,a2,#16
++                BNE     L00
+ 
+-02              SUBS    a4,a4,#1                ;height--
++L02:            SUBS    a4,a4,#1                @height--
+                 LDRHI   v1,[sp,#Arg6]
+-                LDRHI   a2,[sp]                 ;reload width
+-                BLS     %03
++                LDRHI   a2,[sp]                 @reload width
++                BLS     L03
+ 
+-                ;move to start of next scanline
++                @move to start of next scanline
+ 
+                 ADD     lr,a1,a3
+                 ADD     a1,a1,a3
+                 ADD     ip,ip,v1
+ 
+-ucp64lp         SUBS    a2,a2,#16
++ucp64lp:        SUBS    a2,a2,#16
+                 BLO     ucp64end
+ 
+                 PLD     [ip,#64]
+@@ -112,5 +116,5 @@
+ 
+                 B       ucp64lp
+ 
+-03              LDMFD   sp!,{a2,v1-v6,sl,fp,pc}
++L03:            LDMFD   sp!,{a2,v1-v6,sl,fp,pc}
+ 

--- a/toolchains/riscos/packages/tokenize/build.sh
+++ b/toolchains/riscos/packages/tokenize/build.sh
@@ -1,0 +1,14 @@
+#! /bin/sh
+
+PACKAGE_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+HELPERS_DIR=$PACKAGE_DIR/../..
+. $HELPERS_DIR/functions.sh
+
+do_make_bdir
+
+do_svn_fetch tokenize svn://svn.riscos.info/tokenize/trunk/
+
+do_make obj buildlinux/tokenize
+cp buildlinux/tokenize /usr/local/bin/
+
+do_clean_bdir

--- a/toolchains/riscos/packages/toolchain/build.sh
+++ b/toolchains/riscos/packages/toolchain/build.sh
@@ -1,0 +1,16 @@
+#! /bin/sh
+
+PACKAGE_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+HELPERS_DIR=$PACKAGE_DIR/../..
+. $HELPERS_DIR/functions.sh
+
+do_make_bdir
+
+do_svn_fetch gcc4 svn://svn.riscos.info/gccsdk/trunk/gcc4/
+
+echo "export GCCSDK_INSTALL_CROSSBIN=$GCCSDK_INSTALL_CROSSBIN" > gccsdk-params
+echo "export GCCSDK_INSTALL_ENV=$GCCSDK_INSTALL_ENV" >> gccsdk-params
+
+./build-world
+
+do_clean_bdir

--- a/toolchains/riscos/packages/toolchain/patches/fix-urls.patch
+++ b/toolchains/riscos/packages/toolchain/patches/fix-urls.patch
@@ -1,0 +1,105 @@
+Index: Makefile
+===================================================================
+--- a/Makefile	(revision 7208)
++++ b/Makefile	(working copy)
+@@ -41,7 +41,7 @@
+ GDB_VERSION=7.2
+ GMP_VERSION=5.0.1
+ MPFR_VERSION=3.0.1
+-MPC_VERSION=0.8.2
++MPC_VERSION=1.1.0
+ GCC_USE_PPL_CLOOG=yes
+ PPL_VERSION=1.2
+ CLOOG_VERSION=0.15.11
+@@ -640,19 +640,19 @@
+ # Download autoconf source to be used to build binutils:
+ $(SRCORIGDIR)/autoconf-$(AUTOCONF_FOR_BINUTILS_VERSION).tar.bz2:
+ 	-mkdir -p $(SRCORIGDIR)
+-	cd $(SRCORIGDIR) && wget -c http://ftpmirror.gnu.org/autoconf/autoconf-$(AUTOCONF_FOR_BINUTILS_VERSION).tar.bz2
++	cd $(SRCORIGDIR) && wget -c https://ftpmirror.gnu.org/autoconf/autoconf-$(AUTOCONF_FOR_BINUTILS_VERSION).tar.bz2
+ 	touch $@
+ 
+ # Download automake source to be used to build binutils/autoconf-for-binutils:
+ $(SRCORIGDIR)/automake-$(AUTOMAKE_FOR_BINUTILS_VERSION).tar.bz2:
+ 	-mkdir -p $(SRCORIGDIR)
+-	cd $(SRCORIGDIR) && wget -c http://ftpmirror.gnu.org/automake/automake-$(AUTOMAKE_FOR_BINUTILS_VERSION).tar.bz2
++	cd $(SRCORIGDIR) && wget -c https://ftpmirror.gnu.org/automake/automake-$(AUTOMAKE_FOR_BINUTILS_VERSION).tar.bz2
+ 	touch $@
+ 
+ # Download libtool source to be used to build binutils/autoconf-for-binutils:
+ $(SRCORIGDIR)/libtool-$(LIBTOOL_FOR_BINUTILS_VERSION).tar.gz:
+ 	-mkdir -p $(SRCORIGDIR)
+-	cd $(SRCORIGDIR) && wget -c http://ftpmirror.gnu.org/libtool/libtool-$(LIBTOOL_FOR_BINUTILS_VERSION).tar.gz
++	cd $(SRCORIGDIR) && wget -c https://ftpmirror.gnu.org/libtool/libtool-$(LIBTOOL_FOR_BINUTILS_VERSION).tar.gz
+ 	touch $@
+ 
+ ifneq ($(AUTOCONF_FOR_BINUTILS_VERSION),$(AUTOCONF_FOR_GCC_VERSION))
+@@ -659,7 +659,7 @@
+ # Download autoconf source to be used to build gcc:
+ $(SRCORIGDIR)/autoconf-$(AUTOCONF_FOR_GCC_VERSION).tar.bz2:
+ 	-mkdir -p $(SRCORIGDIR)
+-	cd $(SRCORIGDIR) && wget -c http://ftpmirror.gnu.org/autoconf/autoconf-$(AUTOCONF_FOR_GCC_VERSION).tar.bz2
++	cd $(SRCORIGDIR) && wget -c https://ftpmirror.gnu.org/autoconf/autoconf-$(AUTOCONF_FOR_GCC_VERSION).tar.bz2
+ 	touch $@
+ endif
+ 
+@@ -667,7 +667,7 @@
+ # Download automake source to be used to build gcc:
+ $(SRCORIGDIR)/automake-$(AUTOMAKE_FOR_GCC_VERSION).tar.bz2:
+ 	-mkdir -p $(SRCORIGDIR)
+-	cd $(SRCORIGDIR) && wget -c http://ftpmirror.gnu.org/automake/automake-$(AUTOMAKE_FOR_GCC_VERSION).tar.bz2
++	cd $(SRCORIGDIR) && wget -c https://ftpmirror.gnu.org/automake/automake-$(AUTOMAKE_FOR_GCC_VERSION).tar.bz2
+ 	touch $@
+ endif
+ 
+@@ -675,7 +675,7 @@
+ # Download libtool source to be used to build gcc:
+ $(SRCORIGDIR)/libtool-$(LIBTOOL_FOR_GCC_VERSION).tar.gz:
+ 	-mkdir -p $(SRCORIGDIR)
+-	cd $(SRCORIGDIR) && wget -c http://ftpmirror.gnu.org/libtool/libtool-$(LIBTOOL_FOR_GCC_VERSION).tar.gz
++	cd $(SRCORIGDIR) && wget -c https://ftpmirror.gnu.org/libtool/libtool-$(LIBTOOL_FOR_GCC_VERSION).tar.gz
+ 	touch $@
+ endif
+ 
+@@ -682,7 +682,7 @@
+ # Download binutils source:
+ $(SRCORIGDIR)/binutils-$(BINUTILS_VERSION).tar.bz2:
+ 	-mkdir -p $(SRCORIGDIR)
+-	cd $(SRCORIGDIR) && wget -c http://ftpmirror.gnu.org/binutils/binutils-$(BINUTILS_VERSION).tar.bz2
++	cd $(SRCORIGDIR) && wget -c https://ftpmirror.gnu.org/binutils/binutils-$(BINUTILS_VERSION).tar.bz2
+ 	touch $@
+ 
+ ifeq "$(GCC_USE_SCM)" "yes"
+@@ -695,7 +695,7 @@
+ # Download gcc source:
+ $(SRCORIGDIR)/gcc-$(GCC_VERSION).tar.bz2:
+ 	-mkdir -p $(SRCORIGDIR)
+-	cd $(SRCORIGDIR) && wget -c http://ftpmirror.gnu.org/gcc/gcc-$(GCC_VERSION)/gcc-$(GCC_VERSION).tar.bz2
++	cd $(SRCORIGDIR) && wget -c https://ftpmirror.gnu.org/gcc/gcc-$(GCC_VERSION)/gcc-$(GCC_VERSION).tar.bz2
+ 	touch $@
+ endif
+ 
+@@ -708,13 +708,13 @@
+ # Download mpc source:
+ $(SRCORIGDIR)/mpc-$(MPC_VERSION).tar.gz:
+ 	-mkdir -p $(SRCORIGDIR)
+-	cd $(SRCORIGDIR) && wget -c http://www.multiprecision.org/downloads/mpc-$(MPC_VERSION).tar.gz
++	cd $(SRCORIGDIR) && wget -c https://ftpmirror.gnu.org/mpc/mpc-$(MPC_VERSION).tar.gz
+ 	touch $@
+ 
+ # Download mpfr source:
+ $(SRCORIGDIR)/mpfr-$(MPFR_VERSION).tar.bz2:
+ 	-mkdir -p $(SRCORIGDIR)
+-	cd $(SRCORIGDIR) && wget -c http://www.mpfr.org/mpfr-$(MPFR_VERSION)/mpfr-$(MPFR_VERSION).tar.bz2
++	cd $(SRCORIGDIR) && wget -c https://www.mpfr.org/mpfr-$(MPFR_VERSION)/mpfr-$(MPFR_VERSION).tar.bz2
+ 	touch $@
+ 
+ # Download ppl source:
+@@ -738,6 +738,6 @@
+ # Download gdb source:
+ $(SRCORIGDIR)/gdb-$(GDB_VERSION).tar.bz2:
+ 	-mkdir -p $(SRCORIGDIR)
+-	cd $(SRCORIGDIR) && wget -c http://ftpmirror.gnu.org/gdb/gdb-$(GDB_VERSION).tar.bz2
++	cd $(SRCORIGDIR) && wget -c https://ftpmirror.gnu.org/gdb/gdb-$(GDB_VERSION).tar.bz2
+ 	touch $@
+ 


### PR DESCRIPTION
Currently, this only provides the toolchain itself, and does not integrate it into the buildbot system.

See also the following links regarding the patches included:
- https://lists.nongnu.org/archive/html/freetype-devel/2019-09/msg00001.html
- https://sourceforge.net/p/ro-oslib/feature-requests/2/
- https://www.riscos.info/websvn/filedetails.php?repname=gccsdk&path=%2Ftrunk%2Fautobuilder%2Flibraries%2Fsdl%2Flibsdl1.2debian%2Fvideo.p.elf
- https://www.riscos.info/pipermail/gcc/2019-September/006853.html