### PR TITLE
MACOSX/i386: Remove nullptr_t workaround

### DIFF
--- a/toolchains/macosx-i386/Dockerfile.m4
+++ b/toolchains/macosx-i386/Dockerfile.m4
@@ -13,5 +13,3 @@ m4_include(`macosx.m4')m4_dnl
 # So far it worked but several fixes are now needed
 # glew needs cstdint
 COPY cstdint ${TARGET_DIR}/SDK/MacOSX`'MACOSX_SDK_VERSION`'.sdk/usr/include/c++/4.2.1/cstdint
-# nullptr_t is needed in libstdc++
-RUN sed -i -e '/_GLIBCXX_BEGIN_NAMESPACE(std)/a     typedef decltype(nullptr) nullptr_t;' ${TARGET_DIR}/SDK/MacOSX`'MACOSX_SDK_VERSION`'.sdk/usr/include/c++/4.2.1/cstddef


### PR DESCRIPTION
This workaround shouldn't be needed after scummvm/scummvm@50932ff, and it causes stable builds to fail since C++11 support isn't enabled.