### PR TITLE
MXE: Build curl without IDN support

### DIFF
--- a/toolchains/mxe/Dockerfile.m4
+++ b/toolchains/mxe/Dockerfile.m4
@@ -36,6 +36,9 @@ ENV MXE_DIR=/opt/mxe-src \
 	MXE_PREFIX_DIR=/opt/mxe \
 	`MXE_VERSION'=MXE_VERSION
 
+# Add MXE bin directory to PATH
+ENV PATH=$PATH:${MXE_PREFIX_DIR}/bin
+
 local_package(toolchain)
 
 # Install CMake now as it's used for several packages later as it's cleaner
@@ -60,17 +63,15 @@ mxe_package(libmad)
 
 mxe_package(ogg)
 
-mxe_package(theora)
-
 mxe_package(vorbis)
+
+mxe_package(theora)
 
 mxe_package(flac)
 
 mxe_package(libmpeg2)
 
 mxe_package(a52dec)
-
-# No iconv as Win32 API is used instead
 
 local_mxe_package(curl-light)
 
@@ -79,6 +80,8 @@ mxe_package(freetype-bootstrap)
 mxe_package(fribidi)
 
 mxe_package(glew)
+
+mxe_package(libiconv)
 
 local_mxe_package(sdl2)
 

--- a/toolchains/mxe/packages/curl-light/curl-light.mk
+++ b/toolchains/mxe/packages/curl-light/curl-light.mk
@@ -2,7 +2,7 @@
 
 PKG             := curl-light
 $(PKG)_WEBSITE  := https://curl.haxx.se/libcurl/
-$(PKG)_DESCR    := cURL (without deps)
+$(PKG)_DESCR    := cURL (without deps or IDN)
 $(PKG)_IGNORE   = $(curl_IGNORE)
 $(PKG)_VERSION  = $(curl_VERSION)
 $(PKG)_CHECKSUM = $(curl_CHECKSUM)
@@ -23,7 +23,7 @@ define $(PKG)_BUILD
         $(MXE_CONFIGURE_OPTS) \
         --with-winssl \
         --without-ssl \
-        --with-winidn \
+        --without-winidn \
         --enable-sspi \
         --enable-ipv6 \
         --enable-threaded-resolver \


### PR DESCRIPTION
It isn't needed by ScummVM, and having it enabled prevents ScummVM from working with older versions of Windows and/or Internet Explorer.