### PR TITLE
MXE: Improve parallel build

### DIFF
--- a/toolchains/mxe/Dockerfile.m4
+++ b/toolchains/mxe/Dockerfile.m4
@@ -3,8 +3,8 @@ m4_define(`MXE_VERSION',build-2021-04-22)m4_dnl
 m4_include(`paths.m4')m4_dnl
 m4_include(`packages.m4')m4_dnl
 m4_define(`mxe_package', RUN cd "${MXE_DIR}" && \
-	$3 make $1 $2 PREFIX="${MXE_PREFIX_DIR}" && \
-	make PREFIX="${MXE_PREFIX_DIR}" clean-junk && \
+	$3 make $1 $2 -j$(nproc) PREFIX="${MXE_PREFIX_DIR}" && \
+	make PREFIX="${MXE_PREFIX_DIR}" -j$(nproc) clean-junk && \
 	rm -f $HOME/.wget-hsts && find /tmp -mindepth 1 -delete)m4_dnl
 m4_dnl FIXME: don't hardcode /usr/src here
 m4_define(`local_mxe_package', COPY packages/$1 lib-helpers/packages/$1/

--- a/toolchains/mxe/packages/toolchain/build.sh
+++ b/toolchains/mxe/packages/toolchain/build.sh
@@ -4,6 +4,8 @@ PACKAGE_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 HELPERS_DIR=$PACKAGE_DIR/../..
 . $HELPERS_DIR/functions.sh
 
+JOBS=$(nproc)
+
 do_make_bdir
 
 do_git_fetch mxe "https://github.com/mxe/mxe.git" "${MXE_VERSION}"
@@ -23,12 +25,12 @@ cd "${MXE_DIR}"/
 
 # Override PREFIX on command line and not in settings.mk because else it gets overriden too late
 
-make PREFIX="${MXE_PREFIX_DIR}" check-requirements
+make PREFIX="${MXE_PREFIX_DIR}" -j$JOBS check-requirements
 
 # Build compilers
-make PREFIX="${MXE_PREFIX_DIR}" cc
+make PREFIX="${MXE_PREFIX_DIR}" -j$JOBS cc
 
-make PREFIX="${MXE_PREFIX_DIR}" clean-junk
+make PREFIX="${MXE_PREFIX_DIR}" -j$JOBS clean-junk
 
 do_clean_bdir
 rm -f $HOME/.wget-hsts


### PR DESCRIPTION
If `-j` is not used, the packages are built serially (but each
package can still be built in parallel by itself).

If `JOBS` is not used, there is a limit of 6 parallel jobs.