### PR TITLE
MXE: Workaround a bug in autoconf >= 2.70

### DIFF
--- a/toolchains/mxe/packages/fluidsynth-light/glib-light.mk
+++ b/toolchains/mxe/packages/fluidsynth-light/glib-light.mk
@@ -20,7 +20,7 @@ endef
 
 define $(PKG)_BUILD
     # cross build
-    cd '$(SOURCE_DIR)' && NOCONFIGURE=true ./autogen.sh
+    cd '$(SOURCE_DIR)' && NOCONFIGURE=true GTKDOCIZE=false ./autogen.sh
     cd '$(BUILD_DIR)' && '$(SOURCE_DIR)/configure' \
         $(MXE_CONFIGURE_OPTS) \
         --with-threads=win32 \


### PR DESCRIPTION
https://savannah.gnu.org/support/?110503