### PR TITLE
MXE: Fix compilation of retrowave with shared compilers

### DIFF
--- a/toolchains/mxe/packages/retrowave/retrowave.mk
+++ b/toolchains/mxe/packages/retrowave/retrowave.mk
@@ -11,6 +11,7 @@ $(PKG)_DEPS     := cc
 define $(PKG)_BUILD
     cd '$(BUILD_DIR)' && '$(TARGET)-cmake' '$(SOURCE_DIR)' \
         -DCMAKE_INSTALL_PREFIX='$(PREFIX)/$(TARGET)' \
+	-DBUILD_SHARED_LIBS=FALSE \
 	-DRETROWAVE_BUILD_PLAYER=0
 
     '$(TARGET)-cmake' --build '$(BUILD_DIR)' --config Release --target install


### PR DESCRIPTION
```
/opt/mxe/bin/x86_64-w64-mingw32.shared-ld: CMakeFiles/RetroWave.dir/objects.a(STM32_HAL_SPI.c.obj):STM32_HAL_SPI.c:(.text+0x25): undefined reference to `HAL_GPIO_WritePin'
/opt/mxe/bin/x86_64-w64-mingw32.shared-ld: CMakeFiles/RetroWave.dir/objects.a(STM32_HAL_SPI.c.obj):STM32_HAL_SPI.c:(.text+0x3f): undefined reference to `HAL_SPI_TransmitReceive'
/opt/mxe/bin/x86_64-w64-mingw32.shared-ld: CMakeFiles/RetroWave.dir/objects.a(STM32_HAL_SPI.c.obj):STM32_HAL_SPI.c:(.text+0xb5): undefined reference to `HAL_GPIO_WritePin'
/opt/mxe/bin/x86_64-w64-mingw32.shared-ld: CMakeFiles/RetroWave.dir/objects.a(STM32_HAL_SPI.c.obj):STM32_HAL_SPI.c:(.text+0x5b): undefined reference to `HAL_GPIO_WritePin'
collect2: error: ld returned 1 exit status
```