### PR TITLE
MXE: Install lld

### DIFF
--- a/toolchains/mxe/Dockerfile.m4
+++ b/toolchains/mxe/Dockerfile.m4
@@ -25,6 +25,7 @@ RUN apt-get update && \
 		libgdk-pixbuf2.0-bin \
 		libssl-dev \
 		libtool-bin \
+		lld \
 		lzip \
 		p7zip-full \
 		python \
@@ -99,3 +100,5 @@ local_mxe_package(winsparkle)
 local_mxe_package(discord-rpc)
 
 local_mxe_package(retrowave)
+
+local_mxe_package(lld)

--- a/toolchains/mxe/packages/lld/lld.mk
+++ b/toolchains/mxe/packages/lld/lld.mk
@@ -1,0 +1,8 @@
+PKG             := lld
+$(PKG)_WEBSITE  := https://lld.llvm.org
+$(PKG)_DESCR    := LLD Linker
+$(PKG)_VERSION  := system
+
+define $(PKG)_BUILD
+    ln -s /usr/bin/ld.lld '$(MXE_PREFIX_DIR)/bin/$(TARGET)-ld.lld'
+endef


### PR DESCRIPTION
Links ~15x faster than the default ld.

With --enable-all-engines the link time is 3s compared to 47s with ld.