### PR TITLE
FREEMINT: Add FreeMiNT toolchain

### DIFF
--- a/check-versions/config.py
+++ b/check-versions/config.py
@@ -302,6 +302,12 @@ VERSIONS = {
     ('./toolchains/dreamcast/packages/toolchain-sh4/build.sh', 'GCC'): 'ignore',
     ('./toolchains/dreamcast/packages/toolchain-sh4/build.sh', 'NEWLIB'): 'ignore',
 
+    ('./toolchains/freemint/packages/toolchain/build.sh', 'TOOLCHAIN'): {
+        'check': 'git commit',
+        'repository': 'https://github.com/mikrosk/m68k-atari-mint-build',
+        'branch': 'master',
+    },
+
     # GCW0 packages (except toolchain) are set by old firmware
     ('./toolchains/gcw0/packages/alsa-lib/build.sh', 'ALSA_LIB'): 'ignore',
     ('./toolchains/gcw0/packages/etna_viv/build.sh', 'ETNA_VIV'): 'ignore',

--- a/toolchains/common/packages/libsdl1.2/build.sh
+++ b/toolchains/common/packages/libsdl1.2/build.sh
@@ -10,7 +10,7 @@ do_make_bdir
 
 do_http_fetch SDL "https://github.com/libsdl-org/SDL-1.2/archive/${SDL_VERSION}.tar.gz" 'tar xzf'
 
-do_configure
+do_configure "$@"
 do_make
 do_make install
 

--- a/toolchains/freemint/Dockerfile.m4
+++ b/toolchains/freemint/Dockerfile.m4
@@ -1,0 +1,79 @@
+m4_include(`paths.m4')m4_dnl
+m4_include(`packages.m4')m4_dnl
+
+m4_dnl Include Debian base preparation steps
+m4_dnl This ensures all common steps are shared by all toolchains
+m4_include(`debian-toolchain-base.m4')m4_dnl
+
+RUN apt-get update && \
+	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+		bison \
+		flex \
+		gcc \
+		g++ \
+		libgmp-dev \
+		libisl-dev \
+		libmpc-dev \
+		libmpfr-dev \
+		texinfo && \
+	rm -rf /var/lib/apt/lists/*
+
+ENV HOST=m68k-atari-mint
+
+local_package(toolchain)
+
+ENV INSTALL_DIR=/root/gnu-tools/m68000 \
+	PREFIX=/root/gnu-tools/m68000/$HOST/sys-root/usr
+
+# We add PATH here for *-config and platform specific binaries
+ENV \
+	def_binaries(`${HOST}-', `ar, as, c++filt, ld, nm, objcopy, objdump, ranlib, readelf, strings, strip') \
+	def_binaries(`${HOST}-', `gcc, cpp, c++') \
+	CC=${HOST}-gcc \
+	def_aclocal(`${PREFIX}') \
+	def_pkg_config(`${PREFIX}') \
+        PATH=$PATH:${INSTALL_DIR}/bin:${PREFIX}/bin
+
+# TODO: Build m68020-60 and m5475 libraries
+
+helpers_package(zlib)
+
+helpers_package(libpng1.6)
+
+helpers_package(libjpeg-turbo, -DCMAKE_SYSTEM_NAME=Generic -DCMAKE_SYSTEM_PROCESSOR=m68k -DWITH_SIMD=OFF)
+
+helpers_package(giflib,,CFLAGS="${CFLAGS} -fno-PIC")
+
+helpers_package(libmad)
+
+helpers_package(libogg)
+
+helpers_package(libvorbis)
+
+helpers_package(libvorbisidec)
+
+helpers_package(libtheora)
+
+helpers_package(flac, --with-pic=no)
+
+helpers_package(faad2)
+
+# rgb.c:46:22: error: alignment of 'dither' is greater than maximum object file alignment 2
+# helpers_package(mpeg2dec)
+
+helpers_package(a52dec)
+
+# TODO: openssl and curl
+
+# fluidsynth is unlikely to be fast enough.
+
+helpers_package(freetype)
+
+helpers_package(fribidi)
+
+# TODO: GEM, LDG and pth, for SDL
+
+# COPY packages/libsdl1.2 lib-helpers/packages/libsdl1.2/
+helpers_package(libsdl1.2, --disable-video-opengl --disable-threads)
+
+helpers_package(sdl-net1.2)

--- a/toolchains/freemint/packages/toolchain/build.sh
+++ b/toolchains/freemint/packages/toolchain/build.sh
@@ -1,0 +1,20 @@
+#! /bin/sh
+
+# TODO: Use fixed revisions for binutils, gcc, mintlib, mintbin and fdlibm
+TOOLCHAIN_VERSION=b115a55c606cbf4c07a5fd199b2c2eb5b28c4725
+
+PACKAGE_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+HELPERS_DIR=$PACKAGE_DIR/../..
+. $HELPERS_DIR/functions.sh
+
+do_make_bdir
+
+do_http_fetch m68k-atari-mint-build "https://github.com/mikrosk/m68k-atari-mint-build/archive/${TOOLCHAIN_VERSION}.tar.gz" 'tar xzf'
+
+# TODO: Build the m68020-60 and 5475 toolchains as well
+do_make m68000-skip-native
+
+do_clean_bdir
+
+# Cleanup wget HSTS
+rm -f $HOME/.wget-hsts

--- a/toolchains/freemint/packages/toolchain/patches/0001-Work-around-a-bug-in-MiNTLib.patch
+++ b/toolchains/freemint/packages/toolchain/patches/0001-Work-around-a-bug-in-MiNTLib.patch
@@ -1,0 +1,45 @@
+From 20657c9ec506a369ed96c909cbb2979f405d11c8 Mon Sep 17 00:00:00 2001
+From: Cameron Cawley <ccawley2011@gmail.com>
+Date: Mon, 20 Feb 2023 14:44:54 +0000
+Subject: [PATCH] Work around a bug in MiNTLib
+
+---
+ Makefile      |  1 +
+ mintlib.patch | 13 +++++++++++++
+ 2 files changed, 14 insertions(+)
+ create mode 100644 mintlib.patch
+
+diff --git a/Makefile b/Makefile
+index 42a0461..be4a40c 100644
+--- a/Makefile
++++ b/Makefile
+@@ -174,6 +174,7 @@ gcc-${VERSION_GCC}.ok: gmp.patch download_prerequisites.patch
+ mintlib.ok:
+ 	rm -rf $@ ${FOLDER_MINTLIB}
+ 	$(URLGET) ${GITHUB_URL_MINTLIB} | $(UNTAR) > /dev/null
++	cd ${FOLDER_MINTLIB} && patch -p1 < ../mintlib.patch
+ 	touch $@
+ 
+ mintbin.ok:
+diff --git a/mintlib.patch b/mintlib.patch
+new file mode 100644
+index 0000000..21c75b1
+--- /dev/null
++++ b/mintlib.patch
+@@ -0,0 +1,13 @@
++diff --git a/syscall/Makefile b/syscall/Makefile
++index a7d0684..0202962 100644
++--- a/syscall/Makefile
+++++ b/syscall/Makefile
++@@ -49,7 +49,7 @@ gen-syscall: $(gen_objs)
++ 	$(CC) $(gen_objs) -o $@
++ 
++ pars.c pars.h: pars.y
++-	if bison --defines=pars.h.tmp$$$$ --output=pars.c $<; then mv pars.h.tmp$$$$ pars.h; else rm -f pars.h.tmp$$$$; exit 1; fi
+++	bison --defines=pars.h --output=pars.c $< || (rm -f pars.h; exit 1)
++ 
++ pars.o: pars.c pars.h
++ 
+-- 
+2.30.2
+


### PR DESCRIPTION
TODO:
- [ ] Build m68020-60 and m5475 toolchains and libraries
- [ ] Add missing dependencies for SDL 1.2
- [ ] Use fixed commits for `binutils`, `gcc`, `mintlib`, `mintbin` and `fdlibm`.
- [ ] Fix libmpeg2 compiler error
- [ ] Add libraries used by scummvm-tools.
- [ ] Remove the patch once freemint/mintlib#48 is merged.