### PR TITLE
WIN9X: Disable libvpx multithreading

### DIFF
--- a/toolchains/windows-9x/Dockerfile.m4
+++ b/toolchains/windows-9x/Dockerfile.m4
@@ -70,8 +70,9 @@ helpers_package(mpeg2dec)
 COPY packages/a52dec lib-helpers/packages/a52dec/
 helpers_package(a52dec)
 
-# Windows 95 doesn't handle well SSE
-helpers_package(libvpx, --as=nasm --disable-sse)
+# Windows 95 doesn't handle well SSE.
+# Multithreading uses InterlockedCompareExchange, not present in Windows 95.
+helpers_package(libvpx, --as=nasm --disable-sse --disable-multithread)
 
 # TODO: mbedTLS
 


### PR DESCRIPTION
libvpx uses kernel32!InterlockedCompareExchange, but this doesn't exist in Win95, so we currently get a missing export error and can't load.

libvpx only calls InterlockedCompareExchange from its multithreading code, and it can be disabled: https://chromium.googlesource.com/webm/libvpx/+/refs/heads/main/vpx_ports/vpx_once.h

I'm not currently setup to build the toolchain for testing, so I'm only "reasonably" confident this will work. =)