### PR TITLE
BUILDBOT: Restore Nintendo Gamecube Build Target

### DIFF
--- a/buildbot-config/platforms.py
+++ b/buildbot-config/platforms.py
@@ -374,6 +374,26 @@ def dreamcast():
     register_platform(platform)
 dreamcast()
 
+def gamecube():
+    platform = Platform("gamecube")
+    platform.workerimage = "devkitppc"
+    platform.compatibleBuilds = (builds.ScummVMBuild, )
+    platform.configureargs.append("--host=gamecube")
+    platform.buildconfigureargs = {
+        builds.ScummVMBuild: [ "--enable-plugins", "--default-dynamic", "--enable-vkeybd" ],
+    }
+    platform.packaging_cmd = "wiidist"
+    platform.built_files = {
+        builds.ScummVMBuild: [ "wiidist/scummvm" ],
+    }
+    platform.archiveext = "tar.xz"
+
+    platform.description = "Nintendo Gamecube"
+    platform.icon = 'gc'
+
+    register_platform(platform)
+gamecube()
+
 def ios7_arm64():
     platform = Platform("ios7-arm64")
     platform.workerimage = "iphone"


### PR DESCRIPTION
This was removed previously, but supporting this is not a problem since it shares a large amount of code and toolchain with the Wii.

Apart from this, since the GC and Wii are very similar in architecture, it is useful for debugging the Wii since several debug options including GDB Stub over TCP only work with the Gamecube BBA and thus this will help debugging there.
